### PR TITLE
Moved checkout command to earlier in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Installation
 1. Clone the repo and change to the directory of the project
-2. `npm install`
-3. `npm install json-server`
-4. In a terminal window run `npm start`
-5. In another terminal window run `npm run api`
-6. To start at the beginning checkout the first tag: `git checkout 01-Base`
+2. To start at the beginning checkout the first tag: `git checkout 01-Base`
+3. `npm install`
+4. `npm install json-server`
+5. In a terminal window run `npm start`
+6. In another terminal window run `npm run api`
 
 ## Problems?
 If that doesn't work out, there are a series of code sandboxes. They do not have


### PR DESCRIPTION
The api script reference is not in master, so npm run api fails. Maybe the api script reference should be added instead?